### PR TITLE
Remove redundant enclosing lock from BalanceCache

### DIFF
--- a/beacon-chain/cache/active_balance.go
+++ b/beacon-chain/cache/active_balance.go
@@ -3,8 +3,6 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
 	lru "github.com/hashicorp/golang-lru"
@@ -33,21 +31,18 @@ var (
 // BalanceCache is a struct with 1 LRU cache for looking up balance by epoch.
 type BalanceCache struct {
 	cache *lru.Cache
-	lock  sync.RWMutex
 }
 
 // NewEffectiveBalanceCache creates a new effective balance cache for storing/accessing total balance by epoch.
 func NewEffectiveBalanceCache() *BalanceCache {
-	c := &BalanceCache{}
-	c.Clear()
-	return c
+	return &BalanceCache{
+		cache: lruwrpr.New(maxBalanceCacheSize),
+	}
 }
 
-// Clear resets the SyncCommitteeCache to its initial state
+// Clear resets the BalanceCache to its initial state.
 func (c *BalanceCache) Clear() {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.cache = lruwrpr.New(maxBalanceCacheSize)
+	c.cache.Purge()
 }
 
 // AddTotalEffectiveBalance adds a new total effective balance entry for current balance for state `st` into the cache.
@@ -56,9 +51,6 @@ func (c *BalanceCache) AddTotalEffectiveBalance(st state.ReadOnlyBeaconState, ba
 	if err != nil {
 		return err
 	}
-
-	c.lock.Lock()
-	defer c.lock.Unlock()
 
 	_ = c.cache.Add(key, balance)
 	return nil
@@ -70,9 +62,6 @@ func (c *BalanceCache) Get(st state.ReadOnlyBeaconState) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 
 	value, exists := c.cache.Get(key)
 	if !exists {


### PR DESCRIPTION
## Summary
- Removed redundant `sync.RWMutex` from `BalanceCache` struct in `beacon-chain/cache/active_balance.go`
- The underlying `hashicorp/golang-lru` cache already provides internal thread-safe locking, making the external lock unnecessary overhead
- Removed all `c.lock.Lock()/Unlock()/RLock()/RUnlock()` calls from `Clear()`, `AddTotalEffectiveBalance()`, and `Get()`
- Removed unused `sync` import

Closes #13723

## Test plan
- [x] `gofmt` and `goimports` pass
- [x] Gazelle BUILD sync passes
- [x] `bazel build //beacon-chain/cache/...` passes
- [x] `bazel test //beacon-chain/cache/...` passes (2/2 tests pass, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)