### PR TITLE
Remove redundant enclosing lock from SyncCommitteeHeadStateCache

### DIFF
--- a/beacon-chain/cache/sync_committee_head_state.go
+++ b/beacon-chain/cache/sync_committee_head_state.go
@@ -1,8 +1,6 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -13,7 +11,6 @@ import (
 // SyncCommitteeHeadStateCache for the latest head state requested by a sync committee participant.
 type SyncCommitteeHeadStateCache struct {
 	cache *lru.Cache
-	lock  sync.RWMutex
 }
 
 // NewSyncCommitteeHeadState initializes a LRU cache for `SyncCommitteeHeadState` with size of 1.
@@ -24,8 +21,6 @@ func NewSyncCommitteeHeadState() *SyncCommitteeHeadStateCache {
 
 // Put `slot` as key and `state` as value onto the cache.
 func (c *SyncCommitteeHeadStateCache) Put(slot primitives.Slot, st state.BeaconState) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	// Make sure that the provided state is non nil
 	// and is of the correct type.
 	if st == nil || st.IsNil() {
@@ -42,8 +37,6 @@ func (c *SyncCommitteeHeadStateCache) Put(slot primitives.Slot, st state.BeaconS
 
 // Get `state` using `slot` as key. Return nil if nothing is found.
 func (c *SyncCommitteeHeadStateCache) Get(slot primitives.Slot) (state.BeaconState, error) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 	val, exists := c.cache.Get(slot)
 	if !exists {
 		return nil, ErrNotFound


### PR DESCRIPTION
## Summary
- Remove redundant `sync.RWMutex` from `SyncCommitteeHeadStateCache` struct in `beacon-chain/cache/sync_committee_head_state.go`
- The underlying `lru.Cache` (hashicorp/golang-lru) already provides internal thread-safe locking, making the external lock unnecessary overhead
- Removed `lock` field, all `Lock()`/`Unlock()`/`RLock()`/`RUnlock()` calls from `Put()` and `Get()`, and unused `sync` import

Fixes #13723

## Test plan
- [x] `gofmt` and `goimports` pass
- [x] Gazelle BUILD sync — no changes needed
- [x] `bazel build //beacon-chain/cache/...` passes
- [x] `bazel test //beacon-chain/cache/...` — 2/2 tests pass, no new failures vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)